### PR TITLE
fix: bundle jar file in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish package to GitHub Packages
+name: Publish package
 on:
   release:
     types: [created]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,8 @@ jobs:
         run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push GitHub release artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Build package
         run: mvn --batch-mode verify
       - name: Push GitHub release artifact
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +19,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push GitHub release artifact
-        uses: actions/upload-artifact@v3
+        uses: softprops/action-gh-release@v1
         with:
-          name: jar
-          path: target/*.jar
+          files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,8 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Publish package
-        run: mvn --batch-mode deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build package
+        run: mvn --batch-mode verify
       - name: Push GitHub release artifact
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push GitHub release artifact
-        uses: softprops/action-gh-release@v1
+        uses: actions/upload-artifact@v3
         with:
-          files: |
-            target/*.jar
+          name: jar
+          path: target/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,6 @@
         <kafka.version>3.6.0</kafka.version>
     </properties>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/statnett/${project.artifactId}</url>
-        </repository>
-    </distributionManagement>
-
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
GitHub Maven repo is quite useless, as it requires credentials for downloading packages.
This PR will publish the jar file as a release artifact. Unfortunately, using a 3rd party action, as the [official one from GitHub](https://github.com/actions/upload-release-asset) is no longer maintained (and refers to the one used here).

This is how the artifact will be available in the release, from my test project: https://github.com/sverrehu/actions-test/releases/tag/v0.0.9