### PR TITLE
chore(renovate): set renovate to create chore commits for non-major releases of provided packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>statnett/renovate-config"],
+  "extends": [
+    "github>statnett/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPackageNames": [
+        "!java"
+      ],
+      "extends": [
+        ":semanticCommitTypeAll(chore)"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Renovate creates `fix` releases for [provided](https://docs.renovatebot.com/semantic-commits/) packages in Maven, thus triggering Release Please new release PRs. Unless it's a major release, we'd like it to create `chore` releases.